### PR TITLE
Handle new answers when updating quiz questions

### DIFF
--- a/quiz-admin.js
+++ b/quiz-admin.js
@@ -81,6 +81,8 @@ function removeAnswer(btn) {
         node.querySelector('input[type="radio"]').name = `questions[${qIndex}][correct_answer]`;
         node.querySelector('input[type="text"]').name = `questions[${qIndex}][answers][${idx}]`;
         node.querySelector('input[type="text"]').placeholder = `Réponse ${String.fromCharCode(65+idx)}`;
+        const hid = node.querySelector('input[type="hidden"]');
+        if (hid) hid.name = `questions[${qIndex}][answer_ids][${idx}]`;
     });
 }
 
@@ -111,6 +113,8 @@ function renumberQuestions() {
             rd.name = `questions[${idx}][correct_answer]`;
             tx.name = `questions[${idx}][answers][${ai}]`;
             tx.placeholder = `Réponse ${String.fromCharCode(65+ai)}`;
+            const hid = row.querySelector('input[type="hidden"]');
+            if (hid) hid.name = `questions[${idx}][answer_ids][${ai}]`;
         });
     });
 }


### PR DESCRIPTION
## Summary
- Ensure quiz-admin JS renumbers answer id fields so newly added answers submit without `answer_id`
- Detect new and deleted answers in `updateQuestion` to insert or remove them

## Testing
- `node --check quiz-admin.js`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac80fdd8e4832cbff692061d4694dc