### PR TITLE
feat: add quiz import export

### DIFF
--- a/templates/quiz-template.csv
+++ b/templates/quiz-template.csv
@@ -1,0 +1,2 @@
+title,description,question,correct_answer,answer1,answer2,answer3,answer4,comment
+Titre du quiz,Description du quiz,Question 1,0,Réponse A,Réponse B,Réponse C,Réponse D,

--- a/templates/quiz-template.json
+++ b/templates/quiz-template.json
@@ -1,0 +1,12 @@
+{
+  "title": "Titre du quiz",
+  "description": "Description du quiz",
+  "questions": [
+    {
+      "text": "Question 1",
+      "correct_answer": 0,
+      "answers": ["Réponse A", "Réponse B", "Réponse C", "Réponse D"],
+      "comment": ""
+    }
+  ]
+}

--- a/templates/quiz-template.xls
+++ b/templates/quiz-template.xls
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">
+ <Worksheet ss:Name="Quiz">
+  <Table>
+   <Row>
+    <Cell><Data ss:Type="String">title</Data></Cell>
+    <Cell><Data ss:Type="String">description</Data></Cell>
+    <Cell><Data ss:Type="String">question</Data></Cell>
+    <Cell><Data ss:Type="Number">correct_answer</Data></Cell>
+    <Cell><Data ss:Type="String">answer1</Data></Cell>
+    <Cell><Data ss:Type="String">answer2</Data></Cell>
+    <Cell><Data ss:Type="String">answer3</Data></Cell>
+    <Cell><Data ss:Type="String">answer4</Data></Cell>
+    <Cell><Data ss:Type="String">comment</Data></Cell>
+   </Row>
+  </Table>
+ </Worksheet>
+</Workbook>


### PR DESCRIPTION
## Summary
- allow admins to import or export quizzes in JSON, CSV or Excel formats
- provide downloadable templates for each format

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac84a5d45c832cbc88802cc51da596