### PR TITLE
Add quiz timer and success score

### DIFF
--- a/quiz_engine.js
+++ b/quiz_engine.js
@@ -14,6 +14,7 @@ class QuizEngine {
         this.index = 0;
         this.participantId = null;
         this.startTime = null;
+        this.timerInterval = null;
         this.init();
     }
 
@@ -64,6 +65,7 @@ class QuizEngine {
             <div class="panel">
                 <div class="question-header">
                     <div class="badge">Question ${this.index+1}/${this.questions.length}</div>
+                    <div class="badge info" id="quiz-timer">0:00</div>
                     <div class="badge green">${this.escape(this.participantName)}</div>
                 </div>
                 <h2 class="question-text">${this.escape(q.text)}</h2>
@@ -77,6 +79,8 @@ class QuizEngine {
                 <div class="progress"><div class="fill" style="width:${progress}%"></div></div>
             </div>
         `;
+
+        this.startTimer();
 
         c.querySelectorAll('.answer-btn').forEach(btn=>{
             btn.addEventListener('click', async () => {
@@ -119,6 +123,7 @@ class QuizEngine {
             const pct = s && s.total_questions > 0 ? Math.round( (s.correct_answers*100) / s.total_questions ) : 0;
             const c = document.getElementById('quiz-container');
             const dur = this.duration(this.startTime, new Date());
+            clearInterval(this.timerInterval);
 
             const reviewHtml = wrong.length ? `
                 <h3>Révision des erreurs</h3>
@@ -142,6 +147,7 @@ class QuizEngine {
                             <div class="big green">${pct}%</div>
                             <div>Temps: ${dur}</div>
                         </div>
+                        <p class="success-score">Score de réussite : ${pct}%</p>
                     </div>
                     ${reviewHtml}
                     <p class="center"><a class="btn-primary" href="${this.baseUrl}">Retour à l'accueil</a></p>
@@ -150,6 +156,15 @@ class QuizEngine {
         } catch (e) {
             this.error('Erreur lors du calcul du score');
         }
+    }
+
+    startTimer(){
+        const t = document.getElementById('quiz-timer');
+        if(!t) return;
+        if (this.timerInterval) clearInterval(this.timerInterval);
+        const update = () => { t.textContent = this.duration(this.startTime, new Date()); };
+        update();
+        this.timerInterval = setInterval(update, 1000);
     }
 
     duration(a,b){

--- a/style.css
+++ b/style.css
@@ -47,6 +47,7 @@ h3{margin:8px 0;color:#374151}
   margin:4px 0;
 }
 .badge.green{background:var(--success)}
+.badge.info{background:var(--info)}
 
 .panel{
   background:#fff;
@@ -149,6 +150,8 @@ h3{margin:8px 0;color:#374151}
 .review-item{border-top:1px solid #e5e7eb;padding:12px 0}
 .review-item .your-answer{color:var(--danger)}
 .review-item .correct-answer{color:var(--success)}
+
+.success-score{margin-top:8px;font-weight:600;color:var(--success)}
 
 .answers-grid{
   display:grid;


### PR DESCRIPTION
## Summary
- show a live timer during quizzes
- style timer and success score labels
- display success score on completion screen

## Testing
- `node --check quiz_engine.js`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac960699d0832c80d6787311cc001b